### PR TITLE
Adds a registry for IReadable handlers

### DIFF
--- a/src/main/java/com/Da_Technomancer/essentials/blocks/redstone/IReadable.java
+++ b/src/main/java/com/Da_Technomancer/essentials/blocks/redstone/IReadable.java
@@ -6,6 +6,7 @@ import net.minecraft.world.World;
 
 /**
  * Any block can implement this interface to be readable by Reader Circuits (Circuit version of a comparator)
+ * Or can register an instance of this interface with RedstoneUtil::registerReadable to avoid a hard dependency
  */
 public interface IReadable{
 

--- a/src/main/java/com/Da_Technomancer/essentials/blocks/redstone/ReaderCircuit.java
+++ b/src/main/java/com/Da_Technomancer/essentials/blocks/redstone/ReaderCircuit.java
@@ -41,16 +41,18 @@ public class ReaderCircuit extends AbstractCircuit{
 		pos = pos.offset(back);
 		BlockState state = world.getBlockState(pos);
 		Block block = state.getBlock();
-		if(block instanceof IReadable){
-			output = ((IReadable) block).read(world, pos, state);
+		IReadable readable = RedstoneUtil.getReadable(block);
+		if(readable != null){
+			output = readable.read(world, pos, state);
 		}else if(state.hasComparatorInputOverride()){
 			output = state.getComparatorInputOverride(world, pos);
 		}else if(state.isNormalCube(world, pos)){
 			pos = pos.offset(back);
 			state = world.getBlockState(pos);
 			block = state.getBlock();
-			if(block instanceof IReadable){
-				output = ((IReadable) block).read(world, pos, state);
+			readable = RedstoneUtil.getReadable(block);
+			if(readable != null){
+				output = readable.read(world, pos, state);
 			}else if(state.hasComparatorInputOverride()){
 				output = state.getComparatorInputOverride(world, pos);
 			}else{

--- a/src/main/java/com/Da_Technomancer/essentials/blocks/redstone/ReaderCircuit.java
+++ b/src/main/java/com/Da_Technomancer/essentials/blocks/redstone/ReaderCircuit.java
@@ -35,26 +35,25 @@ public class ReaderCircuit extends AbstractCircuit{
 	@Override
 	public float getOutput(float in0, float in1, float in2, CircuitTileEntity te){
 		World world = te.getWorld();
-		BlockPos pos = te.getPos();
 		Direction back = CircuitTileEntity.Orient.BACK.getFacing(te.getBlockState().get(ESProperties.HORIZ_FACING));
+		BlockPos readPos = te.getPos().offset(back);
 		float output;
-		pos = pos.offset(back);
-		BlockState state = te.getBlockState();
+		BlockState state = world.getBlockState(readPos);
 		Block block = state.getBlock();
 		IReadable readable = RedstoneUtil.getReadable(block);
 		if(readable != null){
-			output = readable.read(world, pos, state);
+			output = readable.read(world, readPos, state);
 		}else if(state.hasComparatorInputOverride()){
-			output = state.getComparatorInputOverride(world, pos);
-		}else if(state.isNormalCube(world, pos)){
-			pos = pos.offset(back);
-			state = world.getBlockState(pos);
+			output = state.getComparatorInputOverride(world, readPos);
+		}else if(state.isNormalCube(world, readPos)){
+			readPos = readPos.offset(back);
+			state = world.getBlockState(readPos);
 			block = state.getBlock();
 			readable = RedstoneUtil.getReadable(block);
 			if(readable != null){
-				output = readable.read(world, pos, state);
+				output = readable.read(world, readPos, state);
 			}else if(state.hasComparatorInputOverride()){
-				output = state.getComparatorInputOverride(world, pos);
+				output = state.getComparatorInputOverride(world, readPos);
 			}else{
 				output = 0;
 			}

--- a/src/main/java/com/Da_Technomancer/essentials/blocks/redstone/ReaderCircuit.java
+++ b/src/main/java/com/Da_Technomancer/essentials/blocks/redstone/ReaderCircuit.java
@@ -39,7 +39,7 @@ public class ReaderCircuit extends AbstractCircuit{
 		Direction back = CircuitTileEntity.Orient.BACK.getFacing(te.getBlockState().get(ESProperties.HORIZ_FACING));
 		float output;
 		pos = pos.offset(back);
-		BlockState state = world.getBlockState(pos);
+		BlockState state = te.getBlockState();
 		Block block = state.getBlock();
 		IReadable readable = RedstoneUtil.getReadable(block);
 		if(readable != null){

--- a/src/main/java/com/Da_Technomancer/essentials/blocks/redstone/RedstoneUtil.java
+++ b/src/main/java/com/Da_Technomancer/essentials/blocks/redstone/RedstoneUtil.java
@@ -3,9 +3,13 @@ package com.Da_Technomancer.essentials.blocks.redstone;
 import com.Da_Technomancer.essentials.ESConfig;
 import com.Da_Technomancer.essentials.Essentials;
 import com.Da_Technomancer.essentials.blocks.BlockUtil;
-import net.minecraft.block.*;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.RedstoneWireBlock;
 import net.minecraft.nbt.INBT;
 import net.minecraft.util.Direction;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
@@ -25,9 +29,11 @@ public class RedstoneUtil extends BlockUtil{
 	public static Capability<IRedstoneHandler> REDSTONE_CAPABILITY = null;
 
 	/**
-	 * Public for read-only; Modify using registerCircuit()
+	 * Allows other mods to support being read by a reader circuit without a hard dependency on Essentials
+	 *
+	 * Public for read-only; Modify using registerReadable()
 	 */
-	public static final Map<Block,IReadable> READABLES = new HashMap<>();
+	public static final Map<ResourceLocation, IReadable> READABLES = new HashMap<>();
 
 	/**
 	 * Maximum value that circuits should be able to transfer- signal strengths above this should be capped to this value
@@ -41,10 +47,11 @@ public class RedstoneUtil extends BlockUtil{
 	public static final int DELAY = 2;
 
 	public static void registerReadable(Block block, IReadable readable){
-		if(!READABLES.containsKey(block) || block instanceof IReadable){
-			READABLES.put(block, readable);
+		ResourceLocation blockRegName = block.getRegistryName();
+		if(!READABLES.containsKey(blockRegName) && !(block instanceof IReadable)){
+			READABLES.put(blockRegName, readable);
 		}else{
-			Essentials.logger.warn("Redundant readable handler registration: " + block.getRegistryName());
+			Essentials.logger.warn("Redundant readable handler registration: " + blockRegName);
 		}
 	}
 
@@ -53,7 +60,7 @@ public class RedstoneUtil extends BlockUtil{
 		if(block instanceof IReadable){
 			return ((IReadable) block);
 		}else{
-			return READABLES.get(block); //Return an IReadable handler from the registry instead.
+			return READABLES.get(block.getRegistryName()); //Return an IReadable handler from the registry instead.
 		}
 	}
 

--- a/src/main/java/com/Da_Technomancer/essentials/blocks/redstone/RedstoneUtil.java
+++ b/src/main/java/com/Da_Technomancer/essentials/blocks/redstone/RedstoneUtil.java
@@ -3,9 +3,7 @@ package com.Da_Technomancer.essentials.blocks.redstone;
 import com.Da_Technomancer.essentials.ESConfig;
 import com.Da_Technomancer.essentials.Essentials;
 import com.Da_Technomancer.essentials.blocks.BlockUtil;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
-import net.minecraft.block.RedstoneWireBlock;
+import net.minecraft.block.*;
 import net.minecraft.nbt.INBT;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
@@ -17,12 +15,19 @@ import net.minecraftforge.common.capabilities.CapabilityManager;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 @ParametersAreNonnullByDefault
 public class RedstoneUtil extends BlockUtil{
 
 	@CapabilityInject(IRedstoneHandler.class)
 	public static Capability<IRedstoneHandler> REDSTONE_CAPABILITY = null;
+
+	/**
+	 * Public for read-only; Modify using registerCircuit()
+	 */
+	public static final Map<Block,IReadable> READABLES = new HashMap<>();
 
 	/**
 	 * Maximum value that circuits should be able to transfer- signal strengths above this should be capped to this value
@@ -34,6 +39,23 @@ public class RedstoneUtil extends BlockUtil{
 	public static final float MIN_POWER = -MAX_POWER;
 
 	public static final int DELAY = 2;
+
+	public static void registerReadable(Block block, IReadable readable){
+		if(!READABLES.containsKey(block) || block instanceof IReadable){
+			READABLES.put(block, readable);
+		}else{
+			Essentials.logger.warn("Redundant readable handler registration: " + block.getRegistryName());
+		}
+	}
+
+	@Nullable
+	public static IReadable getReadable(Block block) {
+		if(block instanceof IReadable){
+			return ((IReadable) block);
+		}else{
+			return READABLES.get(block); //Return an IReadable handler from the registry instead.
+		}
+	}
 
 	/**
 	 * Get the maximum range Essentials redstone signals can travel

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -11,7 +11,7 @@ displayName="Essentials" #mandatory
 # displayURL="http://example.com/" #optional
 # A file name (in the root of the mod JAR) containing a logo for display
 # logoFile="examplemod.png" #optional
-credits='''Many textures created by 5284973.
+credits='''Many textures created by 5284973. Code submitted by Bord Listian.
 Translations by XuyuEre, Луксиния Гримхольд, scikirbypoke.''' #optional
 authors="Technomancer" #optional
 # The description text for the mod (multi line!) (#mandatory)


### PR DESCRIPTION
Reader circuits now check:
- IReadable implementation on the block first
- IReadable from registry second
- Comparator output
- Block behind

This allows for IReadable behavior to be added to vanilla blocks and other mod's blocks. This is intended to be a non-breaking change which is why I left the fact it pulls the IReadable from the block in, that way there's no need to change a bunch of Crossroads code to match.

Small downside:
Beehives, Bells and likely other blocks don't push a neighbor notify when they update part of their state, making that bit of their state unreadable to circuits. Fixing this would be possible by making reader circuits tick *if* an IReadable implementation says it wants to be ticked, but I think it's probably out of scope for this PR.