### PR TITLE
Fix several blocks not removing their tile entities when broken

### DIFF
--- a/src/main/java/com/Da_Technomancer/essentials/blocks/MultiPistonBase.java
+++ b/src/main/java/com/Da_Technomancer/essentials/blocks/MultiPistonBase.java
@@ -36,8 +36,6 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import javax.annotation.Nullable;
 import java.util.*;
 
-import net.minecraft.block.AbstractBlock.Properties;
-
 /**
  * Notable differences from a normal piston include:
  * DIST_LIMIT blocks head range, distance controlled by signal strength,
@@ -99,15 +97,22 @@ public class MultiPistonBase extends Block{
 	}
 
 	@Override
-	public void onRemove(BlockState state, World world, BlockPos pos, BlockState newState, boolean isMoving){	BlockState otherState;
-	//An internal change- due to this piston being in the process of extending/retracting (changing world) or due to this piston entering/leaving shifting state should not trigger the breaking of the extension
-	if(!changingWorld && (newState.getBlock() != this || state.setValue(ESProperties.SHIFTING, false) != newState.setValue(ESProperties.SHIFTING, false))){
+	public void onRemove(BlockState state, World world, BlockPos pos, BlockState newState, boolean isMoving){
+		BlockState otherState;
+		//An internal change- due to this piston being in the process of extending/retracting (changing world) or due to this piston entering/leaving shifting state should not trigger the breaking of the extension
+		if(!changingWorld && (newState.getBlock() != this || state.setValue(ESProperties.SHIFTING, false)
+				!= newState.setValue(ESProperties.SHIFTING, false))){
 			//Sanity check included to make sure the adjacent blocks is actually an extension- unlike vanilla pistons, multi pistons are supposed to actually work and not break bedrock
-			if(state.getValue(ESProperties.EXTENDED) && (otherState = world.getBlockState(pos.relative(state.getValue(ESProperties.FACING)))).getBlock() == (sticky ? ESBlocks.multiPistonExtendSticky : ESBlocks.multiPistonExtend) && otherState.getValue(ESProperties.AXIS) == state.getValue(ESProperties.FACING).getAxis()){
+			if(state.getValue(ESProperties.EXTENDED) &&
+					(otherState = world.getBlockState(pos.relative(state.getValue(ESProperties.FACING)))).getBlock() ==
+							(sticky ? ESBlocks.multiPistonExtendSticky : ESBlocks.multiPistonExtend) &&
+					otherState.getValue(ESProperties.AXIS) == state.getValue(ESProperties.FACING).getAxis()){
 				//Break the multipiston head along this
 				world.destroyBlock(pos.relative(state.getValue(ESProperties.FACING)), false);
 			}
 		}
+
+		super.onRemove(state, world, pos, newState, isMoving);
 	}
 
 	@Override

--- a/src/main/java/com/Da_Technomancer/essentials/blocks/redstone/RedstoneReceiver.java
+++ b/src/main/java/com/Da_Technomancer/essentials/blocks/redstone/RedstoneReceiver.java
@@ -137,5 +137,7 @@ public class RedstoneReceiver extends ContainerBlock implements IWireConnect{
 				((RedstoneReceiverTileEntity) te).createLinkEnd(null);
 			}
 		}
+
+		super.onRemove(state, worldIn, pos, newState, isMoving);
 	}
 }

--- a/src/main/java/com/Da_Technomancer/essentials/blocks/redstone/RedstoneTransmitter.java
+++ b/src/main/java/com/Da_Technomancer/essentials/blocks/redstone/RedstoneTransmitter.java
@@ -134,5 +134,7 @@ public class RedstoneTransmitter extends ContainerBlock implements IWireConnect{
 				((RedstoneTransmitterTileEntity) te).linkHelper.unlinkAllEndpoints();
 			}
 		}
+
+		super.onRemove(state, worldIn, pos, newState, isMoving);
 	}
 }


### PR DESCRIPTION
The redstone transmitter & redstone receiver were failing to clean up their tile entities when broken due to a missing super-call.

This likely caused #53, and can also cause a crash (example: http://dpaste.com/553NGDSVS) if another block expecting to have a tile entity is later placed in the position previously occupied by a transmitter or receiver, as the game does not replace tile entities if one already exists.

I also added the super-call to `MultiPistonBase` even though it's not required; might avoid an issue later on. There is a bit of noise in the commit due to reformatting that method a little (should just be whitespace changes).