### PR TITLE
Patchouli guidebook fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -48,4 +48,4 @@ mod_issue_tracker=https://github.com/Crossroads-Development/Essentials/issues
 
 jei_version=19.5.0.30
 cctweaked_version=1.111.0
-patchouli_version=1.20.4-85
+patchouli_version=1.21.1-92

--- a/src/main/java/com/Da_Technomancer/essentials/integration/PatchouliProxy.java
+++ b/src/main/java/com/Da_Technomancer/essentials/integration/PatchouliProxy.java
@@ -1,9 +1,10 @@
 package com.Da_Technomancer.essentials.integration;
 
-import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import vazkii.patchouli.common.book.Book;
 import vazkii.patchouli.common.book.BookRegistry;
+import vazkii.patchouli.common.item.PatchouliDataComponents;
 
 public class PatchouliProxy{
 
@@ -20,10 +21,8 @@ public class PatchouliProxy{
 		for(Book book : BookRegistry.INSTANCE.books.values()){
 			if(book.getBookItem().getItem() == ESIntegration.bookItem && !book.isExternal){
 				ItemStack stack = new ItemStack(ESIntegration.bookItem);
-				CompoundTag cmp = new CompoundTag();
-				cmp.putString("patchouli:book", book.id.toString());
-//				TODO replace w/ DataComponent when Patchouli updates
-//				stack.setTag(cmp);
+				ResourceLocation id = book.id;
+				stack.set(PatchouliDataComponents.BOOK, id);
 				return stack;
 			}
 		};

--- a/src/main/resources/assets/essentials/patchouli_books/manual/en_us/entries/essentials/fertile_soil.json
+++ b/src/main/resources/assets/essentials/patchouli_books/manual/en_us/entries/essentials/fertile_soil.json
@@ -1,31 +1,23 @@
 {
 	"category": "essentials:essentials",
-	"name": "{",
-	"icon": "	"format": 2,",
+	"name": "Fertile Soil",
+	"icon": "essentials:fertile_soil",
 	"sortnum": 0,
 	"priority": false,
 	"read_by_default": "true",
 	"pages": [
 		{
 			"type": "patchouli:spotlight",
-			"title": "{",
-			"item": "	"format": 2,",
-			"text": "	\"category\": \"essentials:essentials\",$(br2)	\"icon\": \"essentials:fertile_soil\",$(br2)	\"read_by_default\": true,$(br2)	\"extra_recipe_mappings\": {$(br2)"
+			"title": "Fertile Soil",
+			"item": "essentials:fertile_soil",
+			"text": "<item>Fertile Soil/$ is an aid to farming. Plants (crops, saplings, etc.) can be planted on <item>Fertile Soil/$ like it was farmland, and they grow as if on hydrated farmland even without water. They also cannot be trampled.\n\nAt random intervals, the plant on top of the soil will spread to adjacent soil (both "
 		},
 		{
 			"type": "patchouli:text",
-			"text": "		\"essentials:fertile_soil\": 0$(br2)	},$(br2)	\"pages\": [$(br2)		{$(br2)			\"type\": \"patchouli:spotlight\",$(br2)			\"title\": \"Fertile Soil\",$(br2)			\"item\": "
-		},
-		{
-			"type": "patchouli:text",
-			"text": "\"essentials:circuit_wrench\",$(br2)			\"text\": \"<item>Fertile Soil/$ is an aid to farming. Plants (crops, saplings, etc.) can be planted on <item>Fertile Soil/$ like it was farmland, and they grow as if on hydrated farmland even without water. They also cannot be trampled.\n\nAt random intervals, the plant on top of the soil will spread to adjacent soil (both "
-		},
-		{
-			"type": "patchouli:text",
-			"text": "to more <item>Fertile Soil/$ and to regular soil), saving the trouble of replanting and enabling the automation of farming without villagers, as long as you leave at least one plant unharvested.\"$(br2)		}$(br2)	]$(br2)}$(br2)"
+			"text": "to more <item>Fertile Soil/$ and to regular soil), saving the trouble of replanting and enabling the automation of farming without villagers, as long as you leave at least one plant unharvested."
 		}
 	],
 	"extra_recipe_mappings": {
-		""name": "Fertile Soil"" : 0
+		"essentials:fertile_soil": 0
 	}
 }

--- a/src/main/resources/data/essentials/recipe/essentials_guide_book.json
+++ b/src/main/resources/data/essentials/recipe/essentials_guide_book.json
@@ -8,7 +8,7 @@
 	"type" : "minecraft:crafting_shapeless",
 	"result" : {
 		"id" : "essentials:guide_book",
-		"nbt" : {
+		"components" : {
 			"patchouli:book" : "essentials:manual"
 		},
 		"count" : 1
@@ -21,5 +21,4 @@
 			"tag" : "c:nuggets/iron"
 		}
 	]
-}
 }

--- a/src/main/resources/python/docs/src/en_us/entries/essentials/fertile_soil.txt
+++ b/src/main/resources/python/docs/src/en_us/entries/essentials/fertile_soil.txt
@@ -11,7 +11,7 @@
 		{
 			"type": "patchouli:spotlight",
 			"title": "Fertile Soil",
-			"item": "essentials:circuit_wrench",
+			"item": "essentials:fertile_soil",
 			"text": "<item>Fertile Soil/$ is an aid to farming. Plants (crops, saplings, etc.) can be planted on <item>Fertile Soil/$ like it was farmland, and they grow as if on hydrated farmland even without water. They also cannot be trampled.\n\nAt random intervals, the plant on top of the soil will spread to adjacent soil (both to more <item>Fertile Soil/$ and to regular soil), saving the trouble of replanting and enabling the automation of farming without villagers, as long as you leave at least one plant unharvested."
 		}
 	]


### PR DESCRIPTION
Added compatibility for the latest 1.21.1 Patchouli version and updated the guidebook data to use the new component format.
I also fixed the fertile soil entry in the guide, which seems to have been generated incorrectly and had the wrong icon.